### PR TITLE
Improve case pagination and ownership filtering

### DIFF
--- a/main line
+++ b/main line
@@ -6,6 +6,8 @@ import os
 
 import re
 
+from collections import Counter
+
 from typing import List, Iterable
 
  
@@ -58,25 +60,75 @@ def get_access_token():
 
 # 🔧 Case Retrieval
 
-def fetch_cases(token):
+def fetch_cases(token, page_size: int = 100) -> List[dict]:
 
     headers = {"Authorization": f"Bearer {token}"}
 
-    url = f"{BASE_URL}/api/v1/agencies/{AGENCY_ID}/cases?pageSize=10"
+    url = f"{BASE_URL}/api/v1/agencies/{AGENCY_ID}/cases"
 
-    try:
+    all_cases: List[dict] = []
 
-        response = requests.get(url, headers=headers)
+    page_number = 1
 
-        response.raise_for_status()
+    while True:
 
-        return response.json().get("data", [])
+        params = {"pageSize": page_size, "pageNumber": page_number}
 
-    except Exception as e:
+        try:
 
-        print(f"❌ Failed to fetch cases: {e}")
+            response = requests.get(url, headers=headers, params=params, timeout=30)
 
-        return []
+            response.raise_for_status()
+
+        except Exception as e:
+
+            print(f"❌ Failed to fetch cases on page {page_number}: {e}")
+
+            break
+
+        payload = response.json() or {}
+
+        page_cases = payload.get("data", [])
+
+        if not page_cases:
+
+            print(f"ℹ️ No cases returned on page {page_number}; stopping pagination.")
+
+            break
+
+        all_cases.extend(page_cases)
+
+        meta = payload.get("meta", {}) or {}
+
+        pagination = meta.get("pagination", {}) or {}
+
+        total_cases = pagination.get("total") or pagination.get("totalItems") or pagination.get("totalCount")
+
+        if total_cases:
+
+            print(
+
+                f"📄 Retrieved page {page_number}: {len(page_cases)} cases (total collected {len(all_cases)}/{total_cases})."
+
+            )
+
+        else:
+
+            print(f"📄 Retrieved page {page_number}: {len(page_cases)} cases (total collected {len(all_cases)}).")
+
+        total_pages = pagination.get("totalPages") or pagination.get("totalPageCount")
+
+        if total_pages and page_number >= total_pages:
+
+            break
+
+        if len(page_cases) < page_size:
+
+            break
+
+        page_number += 1
+
+    return all_cases
 
  
 
@@ -94,7 +146,7 @@ def fetch_case_details(case_id, token):
 
     try:
 
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=30)
 
         response.raise_for_status()
 
@@ -106,7 +158,94 @@ def fetch_case_details(case_id, token):
 
         return None
 
- 
+
+
+# 🔎 Case Ownership Helpers
+
+
+def _extract_agency_ids(value) -> set[str]:
+
+    ids: set[str] = set()
+
+    if value in (None, ""):
+
+        return ids
+
+    if isinstance(value, str):
+
+        ids.add(value)
+
+        return ids
+
+    if isinstance(value, dict):
+
+        possible = value.get("id") or value.get("agencyId") or value.get("agency_id")
+
+        if isinstance(possible, str):
+
+            ids.add(possible)
+
+        for nested in value.values():
+
+            if isinstance(nested, (dict, list)):
+
+                ids.update(_extract_agency_ids(nested))
+
+        return ids
+
+    if isinstance(value, list):
+
+        for item in value:
+
+            ids.update(_extract_agency_ids(item))
+
+    return ids
+
+
+def classify_case_ownership(case_detail: dict) -> str:
+
+    attributes = case_detail.get("attributes", {}) if isinstance(case_detail, dict) else {}
+
+    shared_from = attributes.get("caseSharedFrom")
+
+    shared_to = attributes.get("caseSharedTo")
+
+    share_source = attributes.get("caseShareSource")
+
+    has_any_share_metadata = any(
+
+        field not in (None, [], {}) for field in (shared_from, shared_to, share_source)
+
+    )
+
+    if not has_any_share_metadata:
+
+        return "owned"
+
+    agency_id = AGENCY_ID
+
+    shared_to_ids = _extract_agency_ids(shared_to)
+
+    shared_from_ids = _extract_agency_ids(shared_from)
+
+    share_source_ids = _extract_agency_ids(share_source)
+
+    if agency_id:
+
+        if agency_id in shared_to_ids or agency_id in share_source_ids:
+
+            return "shared"
+
+        if agency_id in shared_from_ids:
+
+            return "owned"
+
+    if shared_to_ids or shared_from_ids or share_source_ids:
+
+        return "excluded"
+
+    return "ambiguous"
+
 
 # 🔧 Case Update
 
@@ -542,9 +681,11 @@ def main_loop():
 
         cases = fetch_cases(token)
 
-        detailed_cases = []
+        detailed_cases: List[dict] = []
 
- 
+        ownership_counts: Counter[str] = Counter()
+
+
 
         for case in cases:
 
@@ -552,11 +693,43 @@ def main_loop():
 
             detail = fetch_case_details(case_id, token)
 
-            if detail:
+            if not detail:
 
-                detailed_cases.append(detail.get("data", {}))
+                continue
 
- 
+            data = detail.get("data", {})
+
+            classification = classify_case_ownership(data)
+
+            ownership_counts[classification] += 1
+
+            if classification in {"owned", "shared"}:
+
+                detailed_cases.append(data)
+
+            elif classification == "ambiguous":
+
+                print(f"⚠️ Case {case_id} has ambiguous ownership metadata; including for safety.")
+
+                detailed_cases.append(data)
+
+            else:
+
+                print(f"🚫 Skipping case {case_id}: not owned by or shared with this agency.")
+
+
+
+        if ownership_counts:
+
+            print("\n📊 Case ownership classification summary:")
+
+            for key in ("owned", "shared", "ambiguous", "excluded"):
+
+                if ownership_counts.get(key):
+
+                    print(f"  - {key.title()}: {ownership_counts[key]}")
+
+
 
         flag_invalid_internal_numbers(detailed_cases)
 


### PR DESCRIPTION
## Summary
- implement Evidence.com case pagination with configurable page size and progress logging
- add ownership classification helpers to include agency-owned and actively shared cases while skipping unrelated items
- enhance main polling loop to respect ownership classifications and report summary counts

## Testing
- python -m compileall 'main line'

------
https://chatgpt.com/codex/tasks/task_e_68d43e5d32488333824689092654e968